### PR TITLE
Change dependencies between installing and updating.

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -6,11 +6,11 @@ class gvm::install(
   exec { 'selfupdate-gvm':
     command => "bash --login -c 'gvm selfupdate'",
     onlyif  => "test -e /Users/${::boxen_user}/.gvm/etc/config",
+    require => Exec['install-gvm'],
   }
 
   exec { 'install-gvm':
     command => "curl -s get.gvmtool.net | bash",
     creates => "/Users/${::boxen_user}/.gvm/etc/config",
-    require => Exec['selfupdate-gvm'],
   }
 }


### PR DESCRIPTION
I'm not super-familiar with Puppet (which is why I was so glad to find this project!), but I think that this ordering is incorrect.  This way the install will always happen first.  Otherwise, the first time boxen is run, GVM is not updated.  This probably isn't a huge issue, but I noticed it while tracking down a local problem.
